### PR TITLE
Make metadata printing optional

### DIFF
--- a/src/BunyanDebugStream.coffee
+++ b/src/BunyanDebugStream.coffee
@@ -116,6 +116,7 @@ class BunyanDebugStream extends Writable
         @_showLoggerName = @options.showLoggerName ? true
         @_showPid = @options.showPid ? true
         @_showLevel = @options.showLevel ? true
+        @_showMetadata = @options.showMetadata ? true
 
     # Runs a stringifier.
     # Appends any keys consumed to `consumed`.
@@ -195,19 +196,20 @@ class BunyanDebugStream extends Writable
             else
                 consumed[key] = true
 
-        # Use JSON.stringify on whatever is left
-        for key, value of entry
-            # Skip fields we don't care about
-            if consumed[key] then continue
+        if @_showMetadata
+          # Use JSON.stringify on whatever is left
+          for key, value of entry
+              # Skip fields we don't care about
+              if consumed[key] then continue
 
-            valueString = JSON.stringify value
-            if valueString?
-                # Make sure value isn't too long.
-                cols = process.stdout.columns
-                start = "#{@_indent}#{key}: "
-                if cols and (valueString.length + start.length) >= cols
-                    valueString = valueString[0...(cols - 3 - start.length)] + "..."
-                values.push "#{start}#{valueString}"
+              valueString = JSON.stringify value
+              if valueString?
+                  # Make sure value isn't too long.
+                  cols = process.stdout.columns
+                  start = "#{@_indent}#{key}: "
+                  if cols and (valueString.length + start.length) >= cols
+                      valueString = valueString[0...(cols - 3 - start.length)] + "..."
+                  values.push "#{start}#{valueString}"
 
         prefixes = if prefixes.length > 0 then "[#{prefixes.join(',')}] " else ''
 


### PR DESCRIPTION
Hi over there!
Is the project alive? Ping! Please send pong. :ping_pong:  

## Motivation

Sometimes metadata objects (that are helpful for analyzing the logs post factum) stand in the way of clarity of console logs printed real-time.

**Before pull request:**
![screenshot from 2018-07-16 16-59-47](https://user-images.githubusercontent.com/1962469/42762825-fe4cf10e-8919-11e8-82dc-f55d638eab33.png)
**After pull request:**
![screenshot from 2018-07-16 17-00-11](https://user-images.githubusercontent.com/1962469/42762829-02cedf30-891a-11e8-81b3-06583d0dc635.png)

## Code changes

* Introduces a new parameter to the options object (`showMetadata`) which is `true` by default
* Skips JSON serializing for non-consumed fields if `showMetadata` is set to `false`.